### PR TITLE
Ability to add umi role assignments outside subscription of managed identity

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -59,8 +59,8 @@ locals {
             role_key = role_k
             role_assignment = {
               principal_id              = module.usermanagedidentity[umi_k].principal_id
-              definition                = strcontains(lower(role_v.definition), lower("/providers/microsoft.authorization/roledefinitions/")) ? "${local.subscription_resource_id}${role_v.definition}" : role_v.definition
-              scope                     = role_v.resource_group_scope_key != null ? module.resourcegroup[role_v.resource_group_scope_key].resource_group_resource_id : "${local.subscription_resource_id}${role_v.relative_scope}"
+              definition                = can(regex("[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}",role_v.definition)) ? role_v.definition : strcontains(lower(role_v.definition), lower("/providers/microsoft.authorization/roledefinitions/")) ? "${local.subscription_resource_id}${role_v.definition}" : role_v.definition
+              scope                     = role_v.resource_group_scope_key != null ? module.resourcegroup[role_v.resource_group_scope_key].resource_group_resource_id : can(regex("[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}",role_v.relative_scope)) ? role_v.relative_scope :"${local.subscription_resource_id}${role_v.relative_scope}"
               condition                 = role_v.condition
               condition_version         = role_v.condition_version
               principal_type            = role_v.principal_type


### PR DESCRIPTION
## Description

Closes https://github.com/Azure/Azure-Landing-Zones/issues/4137

Fixes issue where logic will force local subscription id into scope and definition, removing ability to set role assignments on different subscriptions than local. Suggested fix opens up the logic to pass inn a custom sub id, if set in input parameters using regex to detect if a sub id guid is present.

Example of use:
```
definition =  "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314"
relative_scope = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-hub-public-dns"
```

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks


