### PR TITLE
fix: ensure resource provider registration runs before dependent modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ Default:
   "Microsoft.ContainerRegistry": [],
   "Microsoft.ContainerService": [],
   "Microsoft.CostManagement": [],
+  "Microsoft.Consumption": [],
   "Microsoft.CustomProviders": [],
   "Microsoft.DBforMariaDB": [],
   "Microsoft.DBforMySQL": [],

--- a/main.budget.tf
+++ b/main.budget.tf
@@ -13,4 +13,8 @@ module "budget" {
     start_date = each.value.time_period_start
   }
   budget_notifications = each.value.notifications
+
+  depends_on = [
+    module.resourceproviders,
+  ]
 }

--- a/main.network-security-group.tf
+++ b/main.network-security-group.tf
@@ -13,4 +13,8 @@ module "networksecuritygroup" {
   )
   security_rules = each.value.security_rules
   tags           = each.value.tags
+
+  depends_on = [
+    module.resourceproviders,
+  ]
 }

--- a/main.resource-providers.tf
+++ b/main.resource-providers.tf
@@ -7,11 +7,6 @@ module "resourceproviders" {
   features          = each.value
 
   depends_on = [
-    module.resourcegroup,
-    module.roleassignment,
-    module.roleassignment_umi,
     module.subscription,
-    module.usermanagedidentity,
-    module.virtualnetwork,
   ]
 }

--- a/main.route-table.tf
+++ b/main.route-table.tf
@@ -10,4 +10,8 @@ module "routetable" {
   bgp_route_propagation_enabled = each.value.bgp_route_propagation_enabled
   routes                        = each.value.routes
   tags                          = each.value.tags
+
+  depends_on = [
+    module.resourceproviders,
+  ]
 }

--- a/main.user-assigned-managed-identity.tf
+++ b/main.user-assigned-managed-identity.tf
@@ -12,4 +12,8 @@ module "usermanagedidentity" {
   federated_credentials_github          = each.value.federated_credentials_github
   federated_credentials_terraform_cloud = each.value.federated_credentials_terraform_cloud
   tags                                  = each.value.tags
+
+  depends_on = [
+    module.resourceproviders,
+  ]
 }

--- a/main.virtual-network.tf
+++ b/main.virtual-network.tf
@@ -8,4 +8,8 @@ module "virtualnetwork" {
   subscription_id  = local.subscription_id
   virtual_networks = local.virtual_networks
   enable_telemetry = var.enable_telemetry
+
+  depends_on = [
+    module.resourceproviders,
+  ]
 }

--- a/variables.resource-provider.tf
+++ b/variables.resource-provider.tf
@@ -16,6 +16,7 @@ variable "subscription_register_resource_providers_and_features" {
     "Microsoft.ContainerRegistry"       = [],
     "Microsoft.ContainerService"        = [],
     "Microsoft.CostManagement"          = [],
+    "Microsoft.Consumption"             = [],
     "Microsoft.CustomProviders"         = [],
     "Microsoft.Databricks"              = [],
     "Microsoft.DataLakeAnalytics"       = [],


### PR DESCRIPTION


## Description

Resolves issue [#4124](https://github.com/Azure/Azure-Landing-Zones/issues/4124) by correcting dependency ordering so resource provider registration is not delayed behind network/identity resources.

Also adds Microsoft.Consumption to the default provider registration map for budget scenarios.

Closes [#4124](https://github.com/Azure/Azure-Landing-Zones/issues/4124)


## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
  - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
