### PR TITLE
Add retry handling for transient RoleAssignmentScopeNotAssignableToRo…

### DIFF
--- a/main.role-assignment.tf
+++ b/main.role-assignment.tf
@@ -4,10 +4,15 @@ module "roleassignment" {
   source   = "./modules/role-assignment"
   for_each = { for k, v in var.role_assignments : k => v if var.role_assignment_enabled }
 
-  role_assignment_definition                = local.role_assignments_definitions[each.key]
-  role_assignment_principal_id              = each.value.principal_id
-  role_assignment_scope                     = each.value.resource_group_scope_key != null ? module.resourcegroup[each.value.resource_group_scope_key].resource_group_resource_id : "${local.subscription_resource_id}${each.value.relative_scope}"
-  enable_telemetry                          = var.enable_telemetry
+  role_assignment_definition   = local.role_assignments_definitions[each.key]
+  role_assignment_principal_id = each.value.principal_id
+  role_assignment_scope        = each.value.resource_group_scope_key != null ? module.resourcegroup[each.value.resource_group_scope_key].resource_group_resource_id : "${local.subscription_resource_id}${each.value.relative_scope}"
+  enable_telemetry             = var.enable_telemetry
+  retry = {
+    error_message_regex = [
+      "RoleAssignmentScopeNotAssignableToRoleDefinition"
+    ]
+  }
   role_assignment_condition                 = each.value.condition
   role_assignment_condition_version         = each.value.condition_version
   role_assignment_definition_lookup_enabled = each.value.definition_lookup_enabled

--- a/main.role-assignment.tf
+++ b/main.role-assignment.tf
@@ -4,10 +4,10 @@ module "roleassignment" {
   source   = "./modules/role-assignment"
   for_each = { for k, v in var.role_assignments : k => v if var.role_assignment_enabled }
 
-  role_assignment_definition   = local.role_assignments_definitions[each.key]
-  role_assignment_principal_id = each.value.principal_id
-  role_assignment_scope        = each.value.resource_group_scope_key != null ? module.resourcegroup[each.value.resource_group_scope_key].resource_group_resource_id : "${local.subscription_resource_id}${each.value.relative_scope}"
-  enable_telemetry             = var.enable_telemetry
+  role_assignment_definition                = local.role_assignments_definitions[each.key]
+  role_assignment_principal_id              = each.value.principal_id
+  role_assignment_scope                     = each.value.resource_group_scope_key != null ? module.resourcegroup[each.value.resource_group_scope_key].resource_group_resource_id : "${local.subscription_resource_id}${each.value.relative_scope}"
+  enable_telemetry                          = var.enable_telemetry
   retry = {
     error_message_regex = [
       "RoleAssignmentScopeNotAssignableToRoleDefinition"

--- a/main.role-assignment.tf
+++ b/main.role-assignment.tf
@@ -4,10 +4,10 @@ module "roleassignment" {
   source   = "./modules/role-assignment"
   for_each = { for k, v in var.role_assignments : k => v if var.role_assignment_enabled }
 
-  role_assignment_definition                = local.role_assignments_definitions[each.key]
-  role_assignment_principal_id              = each.value.principal_id
-  role_assignment_scope                     = each.value.resource_group_scope_key != null ? module.resourcegroup[each.value.resource_group_scope_key].resource_group_resource_id : "${local.subscription_resource_id}${each.value.relative_scope}"
-  enable_telemetry                          = var.enable_telemetry
+  role_assignment_definition   = local.role_assignments_definitions[each.key]
+  role_assignment_principal_id = each.value.principal_id
+  role_assignment_scope        = each.value.resource_group_scope_key != null ? module.resourcegroup[each.value.resource_group_scope_key].resource_group_resource_id : "${local.subscription_resource_id}${each.value.relative_scope}"
+  enable_telemetry             = var.enable_telemetry
   retry = {
     error_message_regex = [
       "RoleAssignmentScopeNotAssignableToRoleDefinition"


### PR DESCRIPTION
## Summary

Adds retry handling for transient Azure RBAC propagation failures during subscription vending, to fix https://github.com/Azure/Azure-Landing-Zones/issues/4071

## Root Cause

Custom role definitions scoped at the Management Group level are not immediately available in newly vended subscriptions due to Azure RBAC propagation delays. This results in intermittent failures with:

- `RoleAssignmentScopeNotAssignableToRoleDefinition`

A subsequent deployment succeeds after Azure propagation completes.

The retry capability already exists in the `role-assignment` module and is currently used for `PrincipalNotFound`. This change extends the existing behavior to cover transient RBAC propagation failures.

## Investigation Summary

- Performed multiple reproduction attempts using newly vended subscriptions.
- Tested with Management Group scoped custom roles.
- Observed that failures are intermittent and timing dependent.
- Existing subscriptions and propagated custom roles consistently succeed.
- Behavior matches Azure RBAC propagation delays described in GitHub Issue #4071.

## Fix

Added retry configuration to the `roleassignment` module:

```terraform
retry = {
  error_message_regex = [
    "RoleAssignmentScopeNotAssignableToRoleDefinition"
  ]
}
```

## Validation

- Multiple reproduction attempts completed.
- Executed `terraform fmt -recursive`.
- Executed `terraform init`.
- Executed `terraform validate`.
- Confirmed no impact on existing successful deployments.

## Risk Assessment

- Low risk.
- Uses existing retry infrastructure already present in the `role-assignment` module.
- Change is isolated to `main.role-assignment.tf`.
- No impact on deployments where RBAC propagation has already completed.

