### PR TITLE
Support resource types for NSG and RT in the root module

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ Description: A map of the network security groups to create. The map key must be
 
 - `tags`: A map of tags to apply to the virtual network. [optional - default empty]
 
+### Resource Types
+
+- `resource_types`: An optional object to override the ARM resource types (and their API versions) used by the network security group submodule. [optional]
+  - `this`: The resource type for the network security group, e.g. `Microsoft.Network/networkSecurityGroups@2024-05-01`. [optional]
+  - `security_rule`: The resource type for the security rules, e.g. `Microsoft.Network/networkSecurityGroups/securityRules@2024-05-01`. [optional]
+
 ### Security Rules
 
 - `security_rules` - (Optional) A map of security rules to create within the network network security group. The value is an object with the following fields:
@@ -356,6 +362,10 @@ map(object({
     resource_group_key           = optional(string)
     resource_group_name_existing = optional(string)
     tags                         = optional(map(string))
+    resource_types = optional(object({
+      this          = optional(string)
+      security_rule = optional(string)
+    }), {})
 
     security_rules = optional(map(object({
       access                                     = string
@@ -499,6 +509,9 @@ Description: A map defining route tables and their associated routes to be creat
 
 - `bgp_route_propagation_enabled` (optional): Boolean that controls whether routes learned by BGP are propagated to the route table. Default is `true`.
 - `tags` (optional): A map of key-value pairs for tags associated with the route table.
+- `resource_types` (optional): An object to override the ARM resource types (and their API versions) used by the route table submodule.
+  - `this` (optional): The resource type for the route table, e.g. `Microsoft.Network/routeTables@2024-05-01`.
+  - `route` (optional): The resource type for the routes, e.g. `Microsoft.Network/routeTables/routes@2024-05-01`.
 - `routes` (optional): A map defining routes for the route table. Each route object has the following properties:
 - `name` (required): The name of the route.
 - `address_prefix` (required): The address prefix for the route.
@@ -517,6 +530,10 @@ map(object({
     resource_group_name_existing  = optional(string)
     bgp_route_propagation_enabled = optional(bool, true)
     tags                          = optional(map(string))
+    resource_types = optional(object({
+      this  = optional(string)
+      route = optional(string)
+    }), {})
 
     routes = optional(map(object({
       name                   = string

--- a/locals.tf
+++ b/locals.tf
@@ -14,6 +14,7 @@ locals {
       bgp_route_propagation_enabled = rt_v.bgp_route_propagation_enabled
       tags                          = rt_v.tags
       routes                        = rt_v.routes
+      resource_types                = rt_v.resource_types
     }
   }
   # subscription_id is the id of the subscription into which resources will be created.

--- a/main.network-security-group.tf
+++ b/main.network-security-group.tf
@@ -11,6 +11,7 @@ module "networksecuritygroup" {
     can(module.resourcegroup[each.value.resource_group_key].resource_group_resource_id) ? module.resourcegroup[each.value.resource_group_key].resource_group_resource_id : null,
     each.value.resource_group_name_existing != null ? "${local.subscription_resource_id}/resourceGroups/${each.value.resource_group_name_existing}" : null
   )
+  resource_types = each.value.resource_types
   security_rules = each.value.security_rules
   tags           = each.value.tags
 }

--- a/main.route-table.tf
+++ b/main.route-table.tf
@@ -8,6 +8,7 @@ module "routetable" {
   name                          = each.value.name
   parent_id                     = "${local.subscription_resource_id}/resourceGroups/${each.value.resource_group_name}"
   bgp_route_propagation_enabled = each.value.bgp_route_propagation_enabled
+  resource_types                = each.value.resource_types
   routes                        = each.value.routes
   tags                          = each.value.tags
 }

--- a/variables.network-security-group.tf
+++ b/variables.network-security-group.tf
@@ -11,6 +11,10 @@ variable "network_security_groups" {
     resource_group_key           = optional(string)
     resource_group_name_existing = optional(string)
     tags                         = optional(map(string))
+    resource_types = optional(object({
+      this          = optional(string)
+      security_rule = optional(string)
+    }), {})
 
     security_rules = optional(map(object({
       access                                     = string
@@ -50,6 +54,12 @@ A map of the network security groups to create. The map key must be known at the
 ### Tags
 
 - `tags`: A map of tags to apply to the virtual network. [optional - default empty]
+
+### Resource Types
+
+- `resource_types`: An optional object to override the ARM resource types (and their API versions) used by the network security group submodule. [optional]
+  - `this`: The resource type for the network security group, e.g. `Microsoft.Network/networkSecurityGroups@2024-05-01`. [optional]
+  - `security_rule`: The resource type for the security rules, e.g. `Microsoft.Network/networkSecurityGroups/securityRules@2024-05-01`. [optional]
 
 
 ### Security Rules

--- a/variables.route-table.tf
+++ b/variables.route-table.tf
@@ -12,6 +12,10 @@ variable "route_tables" {
     resource_group_name_existing  = optional(string)
     bgp_route_propagation_enabled = optional(bool, true)
     tags                          = optional(map(string))
+    resource_types = optional(object({
+      this  = optional(string)
+      route = optional(string)
+    }), {})
 
     routes = optional(map(object({
       name                   = string
@@ -33,6 +37,9 @@ A map defining route tables and their associated routes to be created:
 
 - `bgp_route_propagation_enabled` (optional): Boolean that controls whether routes learned by BGP are propagated to the route table. Default is `true`.
 - `tags` (optional): A map of key-value pairs for tags associated with the route table.
+- `resource_types` (optional): An object to override the ARM resource types (and their API versions) used by the route table submodule.
+  - `this` (optional): The resource type for the route table, e.g. `Microsoft.Network/routeTables@2024-05-01`.
+  - `route` (optional): The resource type for the routes, e.g. `Microsoft.Network/routeTables/routes@2024-05-01`.
 - `routes` (optional): A map defining routes for the route table. Each route object has the following properties:
 - `name` (required): The name of the route.
 - `address_prefix` (required): The address prefix for the route.


### PR DESCRIPTION
## Description

Wires the `resource_types` API-version overrides from the `network-security-group`
and `route-table` submodules through to the root module.

Each item in `var.network_security_groups` and `var.route_tables` now accepts an
optional `resource_types` object so consumers can pin the ARM resource type / API
version used for the resource and its child resources:

- `network_security_groups[*].resource_types` → `this`, `security_rule`
- `route_tables[*].resource_types` → `this`, `route`

The fields are optional; when unset each key falls back to the submodule's default
(tested, stable) API version, so this change is fully backwards compatible. Aligns
with AVM `TFFR6` (parent modules must cascade the relevant subset of `resource_types`
to each submodule).

Generated `README.md` was refreshed via pre-commit.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
