### PR TITLE
Restore subnet service_endpoints via virtual_networks v0.20.0

### DIFF
--- a/modules/virtual-network/README.md
+++ b/modules/virtual-network/README.md
@@ -345,7 +345,7 @@ Version: 0.14.1
 
 Source: Azure/avm-res-network-virtualnetwork/azurerm
 
-Version: 0.17.1
+Version: 0.20.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/modules/virtual-network/README.md
+++ b/modules/virtual-network/README.md
@@ -50,8 +50,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
-
 ## Resources
 
 The following resources are used by this module:

--- a/modules/virtual-network/main.tf
+++ b/modules/virtual-network/main.tf
@@ -1,8 +1,13 @@
 # module.virtual_networks uses the Azure Verified Module to create
-# as many virtual networks as is required by the var.virtual_networks input variable
+# as many virtual networks as is required by the var.virtual_networks input variable.
+# The subnet `service_endpoints` set is passed straight through: the wrapper, this submodule and
+# the VNet module all use `optional(set(string))`, and endpoint-list idempotency is handled inside
+# the VNet module via AzAPI list identity keyed on `service`. v0.20.0 is the first release that
+# restores the names-only `service_endpoints` input (VNet PR #130), which fixes ALZ #554 / #4017;
+# versions v0.15.0 through v0.19.0 silently dropped the attribute during object type conversion.
 module "virtual_networks" {
   source   = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version  = "0.17.1"
+  version  = "0.20.0"
   for_each = var.virtual_networks
 
   location      = coalesce(each.value.location, var.location)

--- a/modules/virtual-network/terraform.tf
+++ b/modules/virtual-network/terraform.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "Azure/azapi"
       version = "~> 2.5"
     }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }
   }
 }


### PR DESCRIPTION
The wrapper exposes subnet `service_endpoints` as `optional(set(string))` and forwards subnet objects to `Azure/avm-res-network-virtualnetwork`. VNet releases v0.15.0-v0.19.0 removed that attribute from their subnet object type, so Terraform silently discarded it during object conversion: greenfield subnets were created without the requested endpoints, and upgrades could plan `serviceEndpoints -> null`, removing existing endpoints.

Bump the nested VNet module from 0.17.1 to 0.20.0, the first release that restores the names-only `service_endpoints` input (VNet PR #130). Subnets are passed straight through and the public `service_endpoints = optional(set(string))` contract is unchanged, so callers need no changes. Endpoint-list idempotency is handled inside the VNet module via AzAPI list identity keyed on `service`.

Review the plan when upgrading existing deployments to confirm no unexpected subnet churn.

Refs: Azure/Azure-Landing-Zones#554, Azure/Azure-Landing-Zones#4017

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
