### PR TITLE
fix: update regex for network security group ID validation

### DIFF
--- a/modules/virtual-network/variables.tf
+++ b/modules/virtual-network/variables.tf
@@ -329,7 +329,7 @@ DESCRIPTION
       for k, v in var.virtual_networks :
       [
         for subnet in v.subnets :
-        can(regex("^/subscriptions/[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}/resourceGroups/[\\w-._]{1,89}[^\\s.]/providers/Microsoft.Network/networkSecurityGroups/[\\w-_.]{2,64}$", subnet.network_security_group.id)) if try(subnet["network_security_group"], null) != null
+        can(regex("^/subscriptions/[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}/resourceGroups/[\\w-._]{1,89}[^\\s.]/providers/Microsoft.Network/networkSecurityGroups/[\\w-_.]{1,80}$", subnet.network_security_group.id)) if try(subnet["network_security_group"], null) != null
       ]
     ]))
     error_message = "Network security group resource id must be valid, e.g. /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/networkSecurityGroups/testvnsg."


### PR DESCRIPTION
## Description
Currently the validation for `subnet.network_security_group.id` is enforcing an NSG name between 2 and 64 characters, however the valid name of an NSG is between 1 and 80 characters.

Closes Azure/Azure-Landing-Zones#4246


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
