### PR TITLE
feat(virtual-network): support service endpoints with location

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,6 +964,7 @@ Description: A map of the virtual networks to create. The map key must be known 
     - `key_reference` - The name of the var.route\_tables map key that should be associated with the subnet once it has been provisioned. If you are passing in an `id` value, this will not be used.
   - `default_outbound_access_enabled` - (Optional) Whether to allow internet access from the subnet. Defaults to `false`.
   - `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet.
+  - `service_endpoints_with_location` - (Optional) Service endpoints with location restrictions to associate with the subnet. Cannot be used together with `service_endpoints`.
   - `service_endpoint_policies` - (Optional) The list of Service Endpoint Policy objects with the resource id to associate with the subnet.
     - `id` - The ID of the endpoint policy that should be associated with the subnet.
   - `delegations` - (Optional) A list of delegation objects with the following fields:
@@ -1067,6 +1068,10 @@ map(object({
         }))
         default_outbound_access_enabled = optional(bool, false)
         service_endpoints               = optional(set(string))
+        service_endpoints_with_location = optional(list(object({
+          service   = string
+          locations = optional(list(string), ["*"])
+        })))
         service_endpoint_policies = optional(map(object({
           id = string
         })))

--- a/locals.tf
+++ b/locals.tf
@@ -111,6 +111,7 @@ locals {
         route_table                                   = subnet_v.route_table != null ? { id = coalesce(subnet_v.route_table.id, try(local.virtual_network_subnet_route_table_available_resource_ids[subnet_v.route_table.key_reference], null)) } : null
         default_outbound_access_enabled               = subnet_v.default_outbound_access_enabled
         service_endpoints                             = subnet_v.service_endpoints
+        service_endpoints_with_location               = subnet_v.service_endpoints_with_location
         service_endpoint_policies                     = subnet_v.service_endpoint_policies
         delegations                                   = subnet_v.delegations
         }

--- a/modules/virtual-network/variables.tf
+++ b/modules/virtual-network/variables.tf
@@ -60,6 +60,10 @@ variable "virtual_networks" {
         }))
         default_outbound_access_enabled = optional(bool, false)
         service_endpoints               = optional(set(string))
+        service_endpoints_with_location = optional(list(object({
+          service   = string
+          locations = optional(list(string), ["*"])
+        })))
         service_endpoint_policies = optional(map(object({
           id = string
         })))
@@ -172,6 +176,7 @@ DNS. [optional - default empty list]
     - `id` - The ID of the Route Table which should be associated with the Subnet. Changing this forces a new association to be created.
   - `default_outbound_access_enabled` - (Optional) Whether to allow internet access from the subnet. Defaults to `false`.
   - `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet.
+  - `service_endpoints_with_location` - (Optional) Service endpoints with location restrictions to associate with the subnet. Cannot be used together with `service_endpoints`.
   - `service_endpoint_policies` - (Optional) The list of Service Endpoint Policy objects with the resource id to associate with the subnet.
     - `id` - The ID of the endpoint policy that should be associated with the subnet.
   - `service_endpoint_policy_assignment_enabled` - (Optional) Should the Service Endpoint Policy be assigned to the subnet? Default `true`.
@@ -300,6 +305,16 @@ DESCRIPTION
       ]
     ]))
     error_message = "Each subnet must specify either 'address_prefixes' or 'ipam_pools', but not both."
+  }
+  # validate each subnet uses either service_endpoints or service_endpoints_with_location, but not both
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.virtual_networks : [
+        for subnet in v.subnets :
+        !(subnet.service_endpoints != null && subnet.service_endpoints_with_location != null)
+      ]
+    ]))
+    error_message = "Each subnet may specify either 'service_endpoints' or 'service_endpoints_with_location', but not both."
   }
   # validate subnet address prefixes is not zero length when specified
   validation {

--- a/variables.virtual-network.tf
+++ b/variables.virtual-network.tf
@@ -47,6 +47,10 @@ variable "virtual_networks" {
         }))
         default_outbound_access_enabled = optional(bool, false)
         service_endpoints               = optional(set(string))
+        service_endpoints_with_location = optional(list(object({
+          service   = string
+          locations = optional(list(string), ["*"])
+        })))
         service_endpoint_policies = optional(map(object({
           id = string
         })))
@@ -164,6 +168,7 @@ A map of the virtual networks to create. The map key must be known at the plan s
     - `key_reference` - The name of the var.route_tables map key that should be associated with the subnet once it has been provisioned. If you are passing in an `id` value, this will not be used.
   - `default_outbound_access_enabled` - (Optional) Whether to allow internet access from the subnet. Defaults to `false`.
   - `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet.
+  - `service_endpoints_with_location` - (Optional) Service endpoints with location restrictions to associate with the subnet. Cannot be used together with `service_endpoints`.
   - `service_endpoint_policies` - (Optional) The list of Service Endpoint Policy objects with the resource id to associate with the subnet.
     - `id` - The ID of the endpoint policy that should be associated with the subnet.
   - `delegations` - (Optional) A list of delegation objects with the following fields:
@@ -246,5 +251,15 @@ DESCRIPTION
       ]
     ]))
     error_message = "Each subnet must specify either 'address_prefixes' or 'ipam_pools', but not both."
+  }
+  # validate each subnet uses either service_endpoints or service_endpoints_with_location, but not both
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.virtual_networks : [
+        for sk, sv in v.subnets :
+        !(sv.service_endpoints != null && sv.service_endpoints_with_location != null)
+      ]
+    ]))
+    error_message = "Each subnet may specify either 'service_endpoints' or 'service_endpoints_with_location', but not both."
   }
 }


### PR DESCRIPTION
## Description

Adds support for passing subnet service endpoints with location restrictions through the ALZ subscription vending wrapper to the underlying virtual network module.

The nested virtual network module already supports service_endpoints_with_location, but this wrapper only exposed service_endpoints. This change adds the missing schema fields at the root and virtual-network submodule levels, forwards the value in locals, and documents that service_endpoints and service_endpoints_with_location are mutually exclusive for a subnet.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- terraform fmt -check -recursive
- terraform validate
- git diff --check
- Verified validation rejects a subnet that sets both service_endpoints and service_endpoints_with_location