### PR TITLE
fix: migrate AVM unit test setup hook to PowerShell

### DIFF
--- a/tests/unit/setup.ps1
+++ b/tests/unit/setup.ps1
@@ -1,0 +1,6 @@
+Write-Host "Copy the providers.tf file to the root module directory"
+
+Copy-Item `
+  -Path "./tests/unit/setup/providers.tf" `
+  -Destination "./providers.tf" `
+  -Force

--- a/tests/unit/setup.sh
+++ b/tests/unit/setup.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/bash
-
-echo "Copy the providers.tf file to the root module directory"
-cp ./tests/unit/setup/providers.tf ./providers.tf


### PR DESCRIPTION
## Summary

- Replaced the unsupported `tests/unit/setup.sh` hook with `tests/unit/setup.ps1`
- Converted the provider file copy operation from Bash to PowerShell

## Problem

The AVM Terraform unit test engine supports PowerShell hooks only and failed when it detected `tests/unit/setup.sh`.

## Testing

The setup hook now uses PowerShell syntax and should pass the AVM unit test validation.