### PR TITLE
Ignore AVNM-managed subnet route tables and slim CI for CO fork.

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,29 +1,35 @@
 ---
 name: PR Check
+
 on:
   pull_request:
-    types: ['opened', 'reopened', 'synchronize']
-  merge_group:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  check:
-    permissions: {}
+  validate:
+    name: fmt and validate
     runs-on: ubuntu-latest
     steps:
-      - name: checking for fork
-        shell: pwsh
-        run: |
-          $isFork = "${{ github.event.pull_request.head.repo.fork }}"
-          if($isFork -eq "true") {
-            echo "### WARNING: This workflow is disabled for forked repositories. Please follow the [release branch process](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-create-a-pull-request-to-the-upstream-repository) if end to end tests are required." >> $env:GITHUB_STEP_SUMMARY
-          }
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-  run-managed-workflow:
-    if: github.event.pull_request.head.repo.fork == false
-    uses: Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@main
-    name: run managed workflow
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54bfd3834743f8e2c5786635a4705b5f9d2 # v3.1.2
+        with:
+          terraform_version: 1.14.0
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: Prepare unit test providers
+        run: cp tests/unit/setup/providers.tf providers.tf
+
+      - name: Terraform init
+        run: terraform init -backend=false
+
+      - name: Terraform validate
+        run: terraform validate

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ avmmakefile
 crash.*.log
 crash.log
 examples/*/policy
+providers.tf
 terraform.rc
 .avm/managed-files.json

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,34 @@
+# Cabinet Office fork
+
+Fork of [Azure/terraform-azure-avm-ptn-alz-sub-vending](https://github.com/Azure/terraform-azure-avm-ptn-alz-sub-vending).
+
+## Patches
+
+### AVNM route table coexistence
+
+Corp/online spokes join Azure Virtual Network Manager network groups. AVNM `ManagedOnly` routing attaches managed route tables to subnets after Terraform creates them.
+
+In `modules/virtual-network/main.tf`:
+
+- Bump `Azure/avm-res-network-virtualnetwork/azurerm` to **0.22.1**
+- Set module-wide `ignore_body_changes.virtual_networks_subnets` to `["properties.routeTable"]` ([AVM TFFR8](https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/))
+- Require Terraform **>= 1.11** and AzAPI **>= 2.12**
+
+Remove this fork when upstream sub-vending passes `ignore_body_changes` through and pins a compatible VNet module version.
+
+## Syncing upstream
+
+```bash
+git remote add upstream https://github.com/Azure/terraform-azure-avm-ptn-alz-sub-vending.git
+git fetch upstream --tags
+git merge upstream/main   # or merge a specific release tag
+# Re-apply the AVNM patch if modules/virtual-network/main.tf conflicted
+```
+
+## Releases
+
+Tag Cabinet Office releases as `v<upstream>-co.<n>`, for example `v0.3.2-co.1`.
+
+## CI
+
+Upstream AVM end-to-end tests are replaced with `terraform fmt` and `terraform validate` only. This fork is a thin patch layer consumed by `co-azure-tf-modules/azure-subscription`, not a full AVM contribution repo.

--- a/modules/virtual-network/main.tf
+++ b/modules/virtual-network/main.tf
@@ -7,7 +7,7 @@
 # versions v0.15.0 through v0.19.0 silently dropped the attribute during object type conversion.
 module "virtual_networks" {
   source   = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version  = "0.20.0"
+  version  = "0.22.1"
   for_each = var.virtual_networks
 
   location      = coalesce(each.value.location, var.location)
@@ -26,6 +26,14 @@ module "virtual_networks" {
   name                    = each.value.name
   subnets                 = each.value.subnets
   tags                    = each.value.tags
+
+  # AVNM ManagedOnly routing attaches route tables out-of-band on corp/online spokes.
+  # Ignore subnet routeTable associations so Terraform does not fight AVNM on every apply.
+  ignore_body_changes = {
+    virtual_networks_subnets = {
+      virtual_networks_subnets = ["properties.routeTable"]
+    }
+  }
 }
 
 # module.peering_hub_outbound uses the peering submodule from theAzure Verified Module

--- a/modules/virtual-network/terraform.tf
+++ b/modules/virtual-network/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10"
+  required_version = "~> 1.11"
 
   required_providers {
     azapi = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10"
+  required_version = "~> 1.11"
 
   required_providers {
     azapi = {


### PR DESCRIPTION
## Patching v0.3.2 of the forked AVM repo

Patch needed to apply functionality to ignore routing changes which are managed by AVNM

- Bump avm-res-network-virtualnetwork to 0.22.1 with ignore_body_changes for AVNM ManagedOnly routing
- Replaced upstream AVM e2e PR checks with fmt/validate, and document fork maintenance in FORK.md
